### PR TITLE
Add Healthcheck to dockerfile

### DIFF
--- a/src/go/k8s/Dockerfile.in
+++ b/src/go/k8s/Dockerfile.in
@@ -42,4 +42,7 @@ FROM gcr.io/distroless/static:nonroot as configurator
 WORKDIR /
 COPY --from=builder /workspace/k8s/configurator .
 USER 65532:65532
+
+HEALTHCHECK --interval=30s --timeout=1s --start-period=5s --retries=3 CMD curl -f http://localhost:9644/v1/status/ready || exit 1
+
 ENTRYPOINT ["/configurator"]


### PR DESCRIPTION


## Cover letter

Adds a health check to the Dockerifle using the status endpoint. The check allows docker to determine when Redpanda is ready. This is useful as there is a delay between redpanda starting and it being usable.

Fixes #2749

## Release notes

### Improvements

* Add HEALTCHECK to the Dockerfile
